### PR TITLE
部分未序列化写入操作，无法正常反序列化

### DIFF
--- a/src/CommandHandel/AbstractCommandHandel.php
+++ b/src/CommandHandel/AbstractCommandHandel.php
@@ -113,13 +113,19 @@ Abstract class AbstractCommandHandel
         switch ($this->redis->getConfig()->getSerialize()) {
             case RedisConfig::SERIALIZE_PHP:
                 {
-                    return unserialize($val);
+                    $res = unserialize($val);
+                    if(!$res){
+                        return $val;
+                    }
                     break;
                 }
 
             case RedisConfig::SERIALIZE_JSON:
                 {
-                    return json_decode($val, true);
+                    $res = json_decode($val, true);
+                    if(!$res){
+                        return $val;
+                    }
                     break;
                 }
             default:


### PR DESCRIPTION
像是使用了hincrby这样的命令时，写入未进行序列化，在hget时会返回false，给代码增加了判断，当反序列化或json解析错误时，直接返回数据。