### PR TITLE
修复反序列化失败无法正常返回数据的问题

### DIFF
--- a/src/CommandHandel/AbstractCommandHandel.php
+++ b/src/CommandHandel/AbstractCommandHandel.php
@@ -113,13 +113,19 @@ Abstract class AbstractCommandHandel
         switch ($this->redis->getConfig()->getSerialize()) {
             case RedisConfig::SERIALIZE_PHP:
                 {
-                    return unserialize($val);
+                    $res = unserialize($val);
+                    if(!$res){
+                        return $val;
+                    }
                     break;
                 }
 
             case RedisConfig::SERIALIZE_JSON:
                 {
-                    return json_decode($val, true);
+                    $res = json_decode($val, true);
+                    if(!$res){
+                        return $val;
+                    }
                     break;
                 }
             default:

--- a/src/CommandHandel/AbstractCommandHandel.php
+++ b/src/CommandHandel/AbstractCommandHandel.php
@@ -114,18 +114,14 @@ Abstract class AbstractCommandHandel
             case RedisConfig::SERIALIZE_PHP:
                 {
                     $res = unserialize($val);
-                    if(!$res){
-                        return $val;
-                    }
+                    return $res?$res:$val;
                     break;
                 }
 
             case RedisConfig::SERIALIZE_JSON:
                 {
                     $res = json_decode($val, true);
-                    if(!$res){
-                        return $val;
-                    }
+                    return $res?$res:$val;
                     break;
                 }
             default:


### PR DESCRIPTION
像是使用了hincrby这样的命令时，写入未进行序列化，在hget时会返回false，给代码增加了判断，当反序列化或json解析错误时，直接返回数据。